### PR TITLE
Fix C runtime

### DIFF
--- a/runtimes/c/nile-process.c
+++ b/runtimes/c/nile-process.c
@@ -184,7 +184,7 @@ nile_Process_block_on_producer (nile_Process_t *p)
         p->state = NILE_BLOCKED_ON_PRODUCER;
         pstate = p->producer ? p->producer->state : pstate;
     nile_Lock_rel (&p->lock);
-    return !(pstate == -1 || pstate == NILE_BLOCKED_ON_CONSUMER);
+    return !(pstate == (nile_ProcessState_t ) -1 || pstate == NILE_BLOCKED_ON_CONSUMER);
 }
 
 static nile_Heap_t

--- a/runtimes/c/nile-thread.h
+++ b/runtimes/c/nile-thread.h
@@ -1,6 +1,6 @@
 typedef struct nile_Thread_ nile_Thread_t;
 
-CACHE_ALIGNED struct nile_Thread_ {
+struct CACHE_ALIGNED nile_Thread_ {
     nile_Lock_t      lock;
     nile_Heap_t      private_heap;
     nile_Heap_t      public_heap;

--- a/runtimes/c/nile.c
+++ b/runtimes/c/nile.c
@@ -99,6 +99,12 @@ nile_status (nile_Process_t *init)
     return init->thread->status;
 }
 
+bool
+nile_error (nile_Process_t *init)
+{
+	return (nile_status (init) != NILE_STATUS_OK);
+}
+
 char *
 nile_shutdown (nile_Process_t *init)
 {

--- a/runtimes/c/nile.h
+++ b/runtimes/c/nile.h
@@ -1,6 +1,8 @@
 #ifndef NILE_H
 #define NILE_H
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -28,13 +30,21 @@ typedef enum {
 nile_Status_t
 nile_status (nile_Process_t *init);
 
+bool
+nile_error (nile_Process_t *init);
+
 void
 nile_print_leaks (nile_Process_t *init);
 
 /* Connecting and launching process pipelines */
 
+#define NILE_NULL ((void *) 0)
+
 nile_Process_t *
-nile_Process_pipe (nile_Process_t *p1, nile_Process_t *p2);
+nile_Process_pipe (nile_Process_t *p1, ...);
+
+void
+nile_Process_feed (nile_Process_t *p, float *data, int n);
 
 void
 nile_Process_gate (nile_Process_t *gater, nile_Process_t *gatee);
@@ -57,15 +67,17 @@ nile_Process_t *
 nile_Reverse (nile_Process_t *parent, int in_quantum);
 
 nile_Process_t *
-nile_SortBy (nile_Process_t *parent, int in_quantum, float index);
+nile_SortBy (nile_Process_t *p, int quantum, int index);
 
 nile_Process_t *
-nile_DupZip (nile_Process_t *parent, int in_quantum,
-             nile_Process_t *p1, nile_Process_t *p2);
+nile_DupZip (nile_Process_t *p,  int quantum,
+             nile_Process_t *p1, int p1_out_quantum,
+             nile_Process_t *p2, int p2_out_quantum);
 
 nile_Process_t *
-nile_DupCat (nile_Process_t *parent, int in_quantum,
-             nile_Process_t *p1, nile_Process_t *p2);
+nile_DupCat (nile_Process_t *p,  int quantum,
+             nile_Process_t *p1, int p1_out_quantum,
+             nile_Process_t *p2, int p2_out_quantum);
 
 nile_Process_t *
 nile_Funnel (nile_Process_t *parent);
@@ -75,16 +87,86 @@ nile_Funnel_pour (nile_Process_t *p, float *data, int n, int EOS);
 
 #ifdef NILE_INCLUDE_PROCESS_API
 
+#ifdef _MSC_VER
+#define INLINE static __forceinline
+#else
+#define INLINE static inline
+#endif
+
+/* Real numbers */
+
+#include <math.h>
+
+#define Real nile_Real_t
+
+typedef struct { float f; } nile_Real_t;
+
+INLINE Real  nile_Real     (float f)        { Real r = {f}; return r;        }
+INLINE int   nile_Real_nz  (Real a)         { return  a.f != 0;              }
+INLINE int   nile_Real_toi (Real a)         { return (int) a.f;              }
+INLINE float nile_Real_tof (Real a)         { return       a.f;              }
+INLINE Real  nile_Real_neg (Real a)         { return nile_Real (-a.f);       }
+INLINE Real  nile_Real_sqt (Real a)         { return nile_Real (sqrtf(a.f)); }
+INLINE Real  nile_Real_add (Real a, Real b) { return nile_Real (a.f +  b.f); }
+INLINE Real  nile_Real_sub (Real a, Real b) { return nile_Real (a.f -  b.f); }
+INLINE Real  nile_Real_mul (Real a, Real b) { return nile_Real (a.f *  b.f); }
+INLINE Real  nile_Real_div (Real a, Real b) { return nile_Real (a.f /  b.f); }
+INLINE Real  nile_Real_eq  (Real a, Real b) { return nile_Real (a.f == b.f); }
+INLINE Real  nile_Real_neq (Real a, Real b) { return nile_Real (a.f != b.f); }
+INLINE Real  nile_Real_lt  (Real a, Real b) { return nile_Real (a.f <  b.f); }
+INLINE Real  nile_Real_gt  (Real a, Real b) { return nile_Real (a.f >  b.f); }
+INLINE Real  nile_Real_leq (Real a, Real b) { return nile_Real (a.f <= b.f); }
+INLINE Real  nile_Real_geq (Real a, Real b) { return nile_Real (a.f >= b.f); }
+INLINE Real  nile_Real_or  (Real a, Real b) { return nile_Real (a.f || b.f); }
+INLINE Real  nile_Real_and (Real a, Real b) { return nile_Real (a.f && b.f); }
+INLINE Real  nile_Real_flr (Real a)         { Real b = nile_Real ((int)a.f);
+                                              return nile_Real
+                                                (b.f > a.f ? b.f - 1 : b.f); }
+INLINE Real  nile_Real_clg (Real a)         { Real b = nile_Real ((int)a.f);
+                                              return nile_Real
+                                                (b.f < a.f ? b.f + 1 : b.f); }
+
+/* Stream buffers */
+
+typedef enum {
+    NILE_TAG_NONE,
+    NILE_TAG_QUOTA_HIT,
+    NILE_TAG_OOM,
+} nile_Tag_t;
+
+typedef struct {
+    int        head;
+    int        tail;
+    int        capacity;
+    nile_Tag_t tag;
+    Real       data;
+} nile_Buffer_t;
+
+INLINE void nile_Buffer_push_head (nile_Buffer_t *b, Real r) { (&b->data)[--b->head] = r;    }
+INLINE void nile_Buffer_push_tail (nile_Buffer_t *b, Real r) { (&b->data)[b->tail++] = r;    }
+INLINE Real nile_Buffer_pop_head  (nile_Buffer_t *b)         { return (&b->data)[b->head++]; }
+INLINE int  nile_Buffer_headroom  (nile_Buffer_t *b)         { return b->head;               }
+INLINE int  nile_Buffer_tailroom  (nile_Buffer_t *b)         { return b->capacity - b->tail; }
+INLINE int  nile_Buffer_is_empty  (nile_Buffer_t *b)         { return b->head == b->tail;    }
+INLINE int  nile_Buffer_quota_hit (nile_Buffer_t *b)
+    { return (b->tag == NILE_TAG_QUOTA_HIT) && (nile_Buffer_tailroom (b) < b->capacity / 2); }
+
 /* Process definition API */
 
-typedef int (*nile_Process_work_function_t)
-    (nile_Process_t *p, float *in, int i, int m, float *out, int j, int n);
+typedef nile_Buffer_t *
+(*nile_Process_logue_t) (nile_Process_t *p, nile_Buffer_t *out);
+
+typedef nile_Buffer_t *
+(*nile_Process_body_t)  (nile_Process_t *p, nile_Buffer_t *in, nile_Buffer_t *out);
 
 nile_Process_t *
-nile_Process (nile_Process_t *parent, int in_quantum, int out_quantum,
-              nile_Process_work_function_t prologue,
-              nile_Process_work_function_t body,
-              nile_Process_work_function_t epilogue);
+nile_Process (nile_Process_t *p, int quantum, int sizeof_vars,
+              nile_Process_logue_t prologue,
+              nile_Process_body_t  body,
+              nile_Process_logue_t epilogue);
+
+void *
+nile_Process_vars (nile_Process_t *p);
 
 void *
 nile_Process_memory (nile_Process_t *p);
@@ -95,8 +177,14 @@ nile_Process_advance_output (nile_Process_t *p, float **out, int *j, int *n);
 int
 nile_Process_advance_input (nile_Process_t *p, float **in, int *i, int *m);
 
-void
-nile_Process_prefix_input (nile_Process_t *p, float **in, int *i, int *m);
+nile_Buffer_t *
+nile_Process_append_output (nile_Process_t *p, nile_Buffer_t *out);
+
+nile_Buffer_t *
+nile_Process_prefix_input (nile_Process_t *producer, nile_Buffer_t *in);
+
+nile_Buffer_t *
+nile_Process_swap (nile_Process_t *p, nile_Process_t *sub, nile_Buffer_t *out);
 
 int
 nile_Process_return (nile_Process_t *p, int i, int j, int status);


### PR DESCRIPTION
Restore missing declarations in nile.h

After these changes: 

1) All of the tests inside nile executed and seemed okay.
2) I was able to build the Gezira bindings for Squeak.  All of the GeziraCanvas examples worked (e.g. "GeziraCanvas example3"), and the Frank image seems to work (Lesserphic examples, document editor, etc).