### PR TITLE
Fix JS compiler, text-layout grammar

### DIFF
--- a/compilers/js/nile-ast.js
+++ b/compilers/js/nile-ast.js
@@ -73,6 +73,17 @@ nile.defineASTNode = function(name, fieldnames) {
   nodeConstructor.prototype = nodePrototype;
   nodePrototype.toString = nile.defineASTToString(name, fieldnames);
   nodePrototype.resolve = nile.defineASTResolve(fieldnames);
+
+  Object.defineProperty(nodePrototype, "name", {
+          enumerable: true,
+          get: function() {
+			  return this.__name__;
+          },
+          set: function(value) {
+			  this.__name__ = value;
+          },
+  });
+
   nile[name] = nodePrototype;
 }
 

--- a/examples/text-layout.nl
+++ b/examples/text-layout.nl
@@ -1,9 +1,9 @@
-Glyph <: (w:Real, s:Real)
-Word  <: (w:Real, s:Real, n:Real)
-Point <: (x:Real, y:Real)
+type Glyph = (w:Number, s:Number)
+type Word  = (w:Number, s:Number, n:Number)
+type Point = (x:Number, y:Number)
 
-MakeWords (w:Real) : Glyph >> Word
-    W = (0, 0, 0):Word
+MakeWords (w:Number) : Glyph >> Word
+    W:Word = (0, 0, 0)
     ∀ G
         if G.s ≠ W.s ∨ W.s = 2 ∨ (W.w + G.w > w)
             W' = (G.w, G.s, 1)
@@ -12,7 +12,7 @@ MakeWords (w:Real) : Glyph >> Word
             W' = (W.w + G.w, W.s, W.n + 1)
     >> W
 
-InsertLineBreaks (w:Real) : Word >> Word
+InsertLineBreaks (w:Number) : Word >> Word
     o = 0
     ∀ W
         if W.s = 2
@@ -26,7 +26,7 @@ InsertLineBreaks (w:Real) : Word >> Word
             >> (0, 2, 0)
             >> W
 
-PlaceWords (b:Point, h:Real) : Word >> (Word, Point)
+PlaceWords (b:Point, h:Number) : Word >> (Word, Point)
     x = b.x
     y = b.y
     ∀ W
@@ -37,13 +37,13 @@ PlaceWords (b:Point, h:Real) : Word >> (Word, Point)
         else
             x' = x + W.w
 
-RepeatPlacement : (Word, Point) >> Point
+RepeatPlacement () : (Word, Point) >> Point
     ∀ (W, P) 
         if W.n > 0
             >> P
             << ((W.w, W.s, W.n - 1), P)
 
-PlaceGlyphs : (Point, Glyph) >> Point
+PlaceGlyphs () : (Point, Glyph) >> Point
     x = 0
     y = 0
     o = 0
@@ -55,5 +55,5 @@ PlaceGlyphs : (Point, Glyph) >> Point
             o' = 0 + w
             >> (x' + 0, y')
 
-LayoutText (b:Point, w:Real, h:Real) : Glyph >> Point
-    ⇒ DupZip (MakeWords (w) → InsertLineBreaks (w) → PlaceWords (b, h) → RepeatPlacement, (→)) → PlaceGlyphs
+LayoutText (b:Point, w:Number, h:Number) : Glyph >> Point
+    → DupZip (→ MakeWords (w) → InsertLineBreaks (w) → PlaceWords (b, h) → RepeatPlacement(), → PassThrough ()) → PlaceGlyphs()


### PR DESCRIPTION
The JS compiler is broken under (at least) Safari 10 and Chrome 53. 

When you hit compile, an error will be logged to the console:

> [Error] Variable: a undeclared
	each (prototype.js:598)
	collect (prototype.js:634)
	mapMethod (nile-utils.js:36)
	compileDefs (nile-compiler.html:52)
	onclick (nile-compiler.html:941)`

And looking at the AST that is emitted you'll see the string "nodePrototype" everywhere.  If you try to evaluate the sample, there will be no output, and another error will be logged:

> [Error] Variable: M undeclared
	each (prototype.js:598)
	collect (prototype.js:634)
	mapMethod (nile-utils.js:36)
	(anonymous function) (nile-ast.js:58)
	(anonymous function) (prototype.js:209)
	(anonymous function) (nile-ast-resolve.js:166)
	(anonymous function) (prototype.js:238)
	evaluateBlock (nile-compiler.html:62)
	onclick (nile-compiler.html:961)`

I detailed it in the commit message, but TL;DR – Functions, even anonymous functions, are getting their name property populated.  And the name property can't be changed. 

> ] var foobar = function(){}
 undefined
] foobar.name
 "foobar"
] foobar.name = "hello"
 "hello"
] foobar.name
 "foobar"

So all objects descending from:

>  var nodePrototype = function() { 

Are stuck with "nodePrototype" as their name.  

The fix is awkward, but small and unobtrusive. It overrides the getter/setter for the name property, and reroutes it to a `__name__` property.  With the fix, the AST is fine and evaluate works again.

Additionally the text-layout.nl sample seemed to use an older grammar that was incompatible with the Maru+JS compilers.  So that was a quick attempt at making it compliant with the grammar those expect. 