### PR TITLE
The Gezira code embedded in nile-compiler.html won't compile with the Maru compiler.

### DIFF
--- a/compilers/js/nile-compiler.html
+++ b/compilers/js/nile-compiler.html
@@ -930,7 +930,7 @@ ClipBeziers (min:Point, max:Point) : Bezier >> Bezier
             << (N, B ~ C, C) << (A, A ~ B, N) 
 
 CalculateBounds () : Bezier >> (Point, Point)
-    (min:Point, max:Point) = (∞, -∞)
+    (min:Point, max:Point) = ((∞, ∞), (-∞, -∞))
     ∀ (A, B, C)
         if ¬(A.y = B.y = C.y)
             min' = min ◁ A ◁ B ◁ C

--- a/compilers/js/nile-compiler.html
+++ b/compilers/js/nile-compiler.html
@@ -322,7 +322,7 @@ A:Point ⟂ B:Point : Vector
     ((x1, y1), (x2, y2)) = (A, B)
     v:Vector = (y1 - y2, x2 - x1)
     { v / ‖v‖, if ‖v‖ ≠ 0
-      0,       otherwise  }
+      (0,0),       otherwise  }
 
 M:Matrix P:Point : Point
     (a, b, c, d, e, f) = M

--- a/compilers/js/nile-compiler.html
+++ b/compilers/js/nile-compiler.html
@@ -759,7 +759,7 @@ BicubicFilter (t:Texturer) : Texturer
 
 CompositeClear () : Compositor
     ∀ (A, B)
-        >> 0
+        >> (0, 0, 0, 0)
 
 CompositeSrc () : Compositor
     ∀ (A, B)

--- a/compilers/js/nile-compiler.html
+++ b/compilers/js/nile-compiler.html
@@ -680,7 +680,7 @@ ReflectGradient () : GradientExtender
 
 BeginGradientColor () : Number >> (Number, Color)
     ∀ s
-        >> (s, 0)
+        >> (s, (0, 0, 0, 0))
 
 GradientSpan (A:Color, a:Number, B:Color, b:Number) : GradientColor
     ∀ (s, C)

--- a/compilers/js/nile-compiler.html
+++ b/compilers/js/nile-compiler.html
@@ -700,10 +700,10 @@ ApplyRadialGradient (A:Point, r:Number, e:GradientExtender, c:GradientColor) : T
     → ProjectRadialGradient (A, r) → e → BeginGradientColor () → c → EndGradientColor ()
 
 SumWeightedColors (n:Number) : (Number, Color) >> Color
-    (i, sum:Color) = (1, 0)
+    (i, sum:Color) = (1, (0, 0, 0, 0))
     ∀ (w, C)
         if i = n
-            (i', sum') = (1, 0)
+            (i', sum') = (1, (0, 0, 0, 0))
             >> 0 ▷ (sum + wC) ◁ 1
         else
             (i', sum') = (i + 1, sum + wC)

--- a/compilers/maru/nile-ast-nodes.l
+++ b/compilers/maru/nile-ast-nodes.l
@@ -112,7 +112,7 @@
        (equal? self.type (type a))))
 
 (define-method equal? <nile-primtype> (a)
-  (and (is-a? self <nile-primtype>) (= self.name (name a))))
+  (and (is-a? a <nile-primtype>) (= self.name (name a))))
 
 (define-method equal? <nile-recordtype> (a)
   (and (is-a? a <nile-recordtype>) (equal? self.fields (fields a))))


### PR DESCRIPTION
The Gezira code embedded in compilers/js/nile-compiler.html won't compile under the Maru compiler.

After extracting the code (w/o the prepended prelude.nl) to a file and running it under the Maru compiler, ala:

bash nile-to-c-compiler.sh gezira ../../examples/gezira.nl

It aborts when it tries to ask a nile-recordtype for it's name.  Simple variable typo fix in compilers/maru/nile-ast-nodes.l

With that fixed, code generation still fails due to five type issues Maru found.  After fixing those, both the C and Maru code generators properly generate code. And the JS compiler still appears to be happy. 
